### PR TITLE
PM-16 implemented create pet page

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,8 +3,10 @@ import './App.css';
 import { Routes, Route } from 'react-router-dom';
 import Header from '../Header/Header';
 import PrivateRoute from '../Utils/PrivateRoute';
+import PrivateRouteShelter from '../Utils/PrivateRouteShelter';
 import PublicRoute from '../Utils/PublicRoute';
 import AuthContext from '../../context/AuthContext';
+import AddPetPage from '../../routes/AddPetPage/AddPetPage';
 import FavoritesPage from '../../routes/FavoritesPage/FavoritesPage';
 import HomePage from '../../routes/HomePage/HomePage';
 import LoginPage from '../../routes/LoginPage/LoginPage';
@@ -30,8 +32,18 @@ class App extends Component {
           <Routes>
             <Route path={'/'} element={<HomePage />} />
             <Route path={'/pets'} element={<PetsPage />} />
+            <Route path={'/shelters/:shelterID/pets/create'} element={<AddPetPage />} />
+            {/* temporary set to public page
             <Route
-              path='/login'
+              path="/pets/create"
+              element={
+                <PrivateRouteShelter>
+                  <AddPetPage />
+                </PrivateRouteShelter>
+              }
+            /> */}
+            <Route
+              path="/login"
               element={
                 <PublicRoute>
                   <LoginPage />

--- a/src/components/PetForm/PetForm.js
+++ b/src/components/PetForm/PetForm.js
@@ -1,0 +1,281 @@
+import React, { Component } from 'react';
+import { Checkbox, FormGroup, Input, PrimaryButton, SecondaryButton, Select, TextArea } from '../Utils/Utils';
+import PetsService from '../../services/petsService';
+
+export default class PetForm extends Component {
+  static defaultProps = {
+    pet: {},
+    type: '',
+    shelterID: '',
+    onAddPetSuccess: () => {},
+    onClickCancel: () => {}
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: '',
+      typeOfAnimal: 'Cat',
+      breed: '',
+      sex: 'Female',
+      age: '',
+      size: '',
+      picture: 'test',  // temporary
+      availability: 'Available',
+      description: '',
+      goodWithOtherAnimals: false,
+      goodWithChildren: false,
+      mustBeLeashed: false,
+      neutered: false,
+      vaccinated: false,
+      houseTrained: false,
+      error: null
+    };
+  }
+
+  inputChanged(field, content) {
+    this.setState({ [field]: content });
+  }
+
+  checkBoxChanged(field) {
+    this.setState({ [field]: !this.state[field] });
+  }
+
+  handleAddSubmit = e => {
+    e.preventDefault();
+    const pet = this.getPet();
+
+    PetsService.postPet(pet)
+      .then(res => {
+        this.props.onAddPetSuccess(res.insertId);
+      })
+      .catch(res => {
+        this.setState({ error: res.error });
+      });
+  }
+
+  handleUpdateSubmit = e => {
+    // TODO
+  }
+
+  getPet() {
+    const {
+      name,
+      typeOfAnimal,
+      breed,
+      sex,
+      age,
+      size,
+      picture,
+      availability,
+      description,
+      goodWithOtherAnimals,
+      goodWithChildren,
+      mustBeLeashed,
+      neutered,
+      vaccinated,
+      houseTrained
+    } = this.state;
+    return {
+      name,
+      typeOfAnimal,
+      breed,
+      sex,
+      age: age === '' ? null : age,
+      size,
+      picture,
+      availability,
+      description,
+      goodWithOtherAnimals,
+      goodWithChildren,
+      mustBeLeashed,
+      neutered,
+      vaccinated,
+      houseTrained,
+      shelterID: this.props.shelterID
+    };
+  }
+
+  render() {
+    const {
+      name,
+      typeOfAnimal,
+      breed,
+      sex,
+      age,
+      size,
+      picture,
+      availability,
+      description,
+      goodWithOtherAnimals,
+      goodWithChildren,
+      mustBeLeashed,
+      neutered,
+      vaccinated,
+      houseTrained,
+      error
+    } = this.state;
+
+    return (
+      <form
+        onSubmit={this.props.type === 'create'
+          ? this.handleAddSubmit
+          : this.handleUpdateSubmit
+        }
+      >
+        {error && <div className='alert alert-danger' role='alert'>{error}</div>}
+        <FormGroup>
+          <label htmlFor='name'>Name</label>
+          <Input
+            name='name'
+            id='name'
+            value={name}
+            onChange={e => this.inputChanged('name', e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='typeOfAnimal'>Type Of Animal</label>
+          <Select
+            name='typeOfAnimal'
+            id='typeOfAnimal'
+            value={typeOfAnimal}
+            onChange={e => this.inputChanged('typeOfAnimal', e.target.value)}
+            required
+          >
+            <option value='Cat'>Cat</option>
+            <option value='Dog'>Dog</option>
+            <option value='Other'>Other</option>
+          </Select>
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='breed'>Breed</label>
+          <Input
+            name='breed'
+            id='breed'
+            value={breed}
+            onChange={e => this.inputChanged('breed', e.target.value)}
+            required
+          />
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='sex'>Sex</label>
+          <Select
+            name='sex'
+            id='sex'
+            value={sex}
+            onChange={e => this.inputChanged('sex', e.target.value)}
+            required
+          >
+            <option value='Female'>Female</option>
+            <option value='Male'>Male</option>
+          </Select>
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='age'>Age</label>
+          <Input
+            name='age'
+            id='age'
+            type='number'
+            value={age}
+            onChange={e => this.inputChanged('age', e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='size'>Size</label>
+          <Input
+            name='size'
+            id='size'
+            value={size}
+            onChange={e => this.inputChanged('size', e.target.value)}
+            required
+          />
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='availability'>Availability</label>
+          <Select
+            name='availability'
+            id='availability'
+            value={availability}
+            onChange={e => this.inputChanged('availability', e.target.value)}
+            required
+          >
+            <option value='Available'>Available</option>
+            <option value='Not Available'>Not Available</option>
+            <option value='Pending'>Pending</option>
+            <option value='Adopted'>Adopted</option>
+          </Select>
+        </FormGroup>
+        <FormGroup>
+          <label htmlFor='description'>Description</label>
+          <TextArea
+            name='description'
+            id='description'
+            value={description}
+            onChange={e => this.inputChanged('description', e.target.value)}
+            required
+          />
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='goodWithOtherAnimals'
+            id='goodWithOtherAnimals'
+            checked={goodWithOtherAnimals}
+            onChange={e => this.checkBoxChanged('goodWithOtherAnimals')}
+          />
+          <label className='form-check-label' htmlFor='goodWithOtherAnimals'>Good with Other Animals</label>
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='goodWithChildren'
+            id='goodWithChildren'
+            checked={goodWithChildren}
+            onChange={e => this.checkBoxChanged('goodWithChildren')}
+          />
+          <label className='form-check-label' htmlFor='goodWithChildren'>Good with Children</label>
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='mustBeLeashed'
+            id='mustBeLeashed'
+            checked={mustBeLeashed}
+            onChange={e => this.checkBoxChanged('mustBeLeashed')}
+          />
+          <label className='form-check-label' htmlFor='mustBeLeashed'>Must Be Leashed</label>
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='neutered'
+            id='neutered'
+            checked={neutered}
+            onChange={e => this.checkBoxChanged('neutered')}
+          />
+          <label className='form-check-label' htmlFor='neutered'>Neutered</label>
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='vaccinated'
+            id='vaccinated'
+            checked={vaccinated}
+            onChange={e => this.checkBoxChanged('vaccinated')}
+          />
+          <label className='form-check-label' htmlFor='vaccinated'>Vaccinated</label>
+        </FormGroup>
+        <FormGroup className='form-check'>
+          <Checkbox
+            name='houseTrained'
+            id='houseTrained'
+            checked={houseTrained}
+            onChange={e => this.checkBoxChanged('houseTrained')}
+          />
+          <label className='form-check-label' htmlFor='houseTrained'>House Trained</label>
+        </FormGroup>
+        <PrimaryButton type='submit'>
+          Submit
+        </PrimaryButton>
+        <SecondaryButton type='button' onClick={this.props.onClickCancel}>
+          Cancel
+        </SecondaryButton>
+      </form>
+    );
+  }
+}

--- a/src/components/Utils/PrivateRouteShelter.js
+++ b/src/components/Utils/PrivateRouteShelter.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import AuthService from '../../services/authService';
+
+export default function PrivateRouteShelter({ children }) {
+  return AuthService.isLoggedIn() && AuthService.isShelterAdmin()
+    ? children
+    : <Navigate to={'/login/shelter'} />;
+}

--- a/src/components/Utils/Utils.js
+++ b/src/components/Utils/Utils.js
@@ -6,6 +6,55 @@ import {
   faHeart
 } from '@fortawesome/free-solid-svg-icons';
 
+// page container
+export function Section({ className, ...props }) {
+  return (
+    <section className={['container', className].join(' ')} {...props} />
+  );
+}
+
+export function FormGroup({ className, ...props }) {
+  return (
+    <div className={['form-group', className].join(' ')} {...props} />
+  );
+}
+
+export function Input({ className, type, ...props }) {
+  return (
+    <input className={['form-control', className].join(' ')} type={type || 'text'} {...props} />
+  );
+}
+
+export function Checkbox({ className, ...props }) {
+  return (
+    <input className={['form-check-input', className].join(' ')} type='checkbox' {...props} />
+  );
+}
+
+export function Select({ className, ...props }) {
+  return (
+    <select className={['form-control', className].join(' ')} {...props} />
+  );
+}
+
+export function TextArea({ className, ...props }) {
+  return (
+    <textarea className={['form-control', className].join(' ')} {...props} />
+  );
+}
+
+export function PrimaryButton({ className, ...props }) {
+  return (
+    <button className={['btn btn-primary btn-block', className].join(' ')} {...props} />
+  );
+}
+
+export function SecondaryButton({ className, ...props }) {
+  return (
+    <button className={['btn btn-outline-primary btn-block', className].join(' ')} {...props} />
+  );
+}
+
 export function registerIcons() {
   library.add(
     faCog,    // settings

--- a/src/routes/AddPetPage/AddPetPage.js
+++ b/src/routes/AddPetPage/AddPetPage.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router';
+import PetForm from '../../components/PetForm/PetForm';
+import { Section } from '../../components/Utils/Utils';
+
+export default function AddPetPage () {
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const handleAddPetSuccess = petID => {
+    navigate(`/pets/${petID}`);
+  }
+
+  const handleClickCancel = () => {
+    navigate(`/shelters/${params.shelterID}/pets`);
+  }
+
+  return (
+    <Section>
+      <h2>Add A Pet</h2>
+      <PetForm
+        type='create'
+        shelterID={params.shelterID}
+        onAddPetSuccess={handleAddPetSuccess}
+        onClickCancel={handleClickCancel}
+      />
+    </Section>
+  );
+}

--- a/src/routes/HomePage/HomePage.js
+++ b/src/routes/HomePage/HomePage.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Section } from '../../components/Utils/Utils';
 import './HomePage.css';
 
 export default function HomePage() {
   return (
-    <>
+    <Section>
       <h2>Home</h2>
-    </>
+    </Section>
   );
 }

--- a/src/routes/PetsPage/PetsPage.js
+++ b/src/routes/PetsPage/PetsPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PetCard from '../../components/PetCard/PetCard';
+import { Section } from '../../components/Utils/Utils';
 import PetsService from '../../services/petsService';
 
 export default class PetsPage extends Component {
@@ -37,7 +38,7 @@ export default class PetsPage extends Component {
     // no pets exist
     if (petCount === 0) {
       return (
-        <div className="alert alert-success" role="alert">
+        <div className='alert alert-success' role='alert'>
           More pets will be available soon! Check back later :)
         </div>
       );
@@ -46,9 +47,9 @@ export default class PetsPage extends Component {
     // place pets in a 3-cols grid
     const petRows = Math.floor(petCount / 3) + (petCount % 3 === 0 ? 0 : 1);
     return (
-      <div className='container'>
+      <Section>
         {[...Array(petRows)].map((_, i) => this.renderPetRow(i * 3))}
-      </div>
+      </Section>
     );
   }
 }

--- a/src/services/petsService.js
+++ b/src/services/petsService.js
@@ -9,6 +9,20 @@ const PetsService = {
           : res.json()
       );
   },
+  postPet(newPet) {
+    return fetch(`${HOSTNAME}/pets`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ newPet })
+    })
+      .then(res =>
+        (!res.ok)
+          ? res.json().then(e => Promise.reject(e))
+          : res.json()
+      );
+  }
 };
 
 export default PetsService;


### PR DESCRIPTION
Implemented create pet page:

- Changed path to /shelters/:shelterID/pets/create (since only shelters can create pets I feel it's more like a shelter's page)
- PetForm.js can be reused for update pet page
- Created a bunch of simple elements in Utils.js that can be reused (including section, form inputs and buttons, so we don't have to write the classNames everytime and we can make sure the style is consistent)